### PR TITLE
Enable local reporting of missing lines

### DIFF
--- a/XivVoices/Engine/Database.cs
+++ b/XivVoices/Engine/Database.cs
@@ -868,8 +868,7 @@ namespace XivVoices.Engine
 
         public string VoiceDataExists(string voiceName, string speaker, string sentence)
         {
-            string newSpeaker = speaker;
-            string cleanedSentence = CleanedSentenceAndSpeakerForFile(voiceName, ref newSpeaker, sentence);
+            string cleanedSentence = CleanedSentenceAndSpeakerForFile(voiceName, ref speaker, sentence);
 
             string actorDirectory   = VoiceFilesPath   + "/" + voiceName;
             string speakerDirectory = actorDirectory   + "/" + speaker;

--- a/XivVoices/Engine/Database.cs
+++ b/XivVoices/Engine/Database.cs
@@ -868,25 +868,12 @@ namespace XivVoices.Engine
 
         public string VoiceDataExists(string voiceName, string speaker, string sentence)
         {
-            speaker = Regex.Replace(speaker, @"[^a-zA-Z0-9 _-]", "").Replace(" ", "_").Replace("-", "_");
-            
-            // Create a Path
-            string cleanedSentence = Regex.Replace(sentence, "<[^<]*>", "");
-            cleanedSentence = RemoveSymbolsAndLowercase(cleanedSentence);
-            string actorDirectory = VoiceFilesPath + "/" + voiceName;
-            string speakerDirectory = actorDirectory + "/" + speaker;
+            string newSpeaker = speaker;
+            string cleanedSentence = CleanedSentenceAndSpeakerForFile(voiceName, ref newSpeaker, sentence);
 
-            string filePath = speakerDirectory + "/" + cleanedSentence;
-            int missingFromDirectoryPath = 0;
-            if (DirectoryPath.Length < 13)
-                missingFromDirectoryPath = 13 - DirectoryPath.Length;
-            int maxLength = 200 - ((DirectoryPath + "/" + voiceName + "/" + speaker).Length);
-            maxLength -= missingFromDirectoryPath;
-            if (cleanedSentence.Length > maxLength)
-                cleanedSentence = cleanedSentence.Substring(0, maxLength);
-
-            cleanedSentence = Regex.Replace(cleanedSentence, @"[^a-zA-Z0-9 _-]", "").Replace(" ", "_").Replace("-", "_");
-            filePath = speakerDirectory + "/" + cleanedSentence;
+            string actorDirectory   = VoiceFilesPath   + "/" + voiceName;
+            string speakerDirectory = actorDirectory   + "/" + speaker;
+            string filePath         = speakerDirectory + "/" + cleanedSentence;
 
             // Get Wav from filePath if it exists and return it as AudioClip, if not, return Null
             Plugin.PluginLog.Information($"looking for path [{filePath + ".ogg"}]");
@@ -920,6 +907,27 @@ namespace XivVoices.Engine
             else
                 return null;
         }
+
+        public string CleanedSentenceAndSpeakerForFile(string voiceName, ref string speaker, string sentence)
+        {
+            speaker = Regex.Replace(speaker, @"[^a-zA-Z0-9 _-]", "").Replace(" ", "_").Replace("-", "_");
+            
+            // Create a Path
+            string cleanedSentence = Regex.Replace(sentence, "<[^<]*>", "");
+            cleanedSentence = RemoveSymbolsAndLowercase(cleanedSentence);
+
+            int missingFromDirectoryPath = 0;
+            if (DirectoryPath.Length < 13)
+                missingFromDirectoryPath = 13 - DirectoryPath.Length;
+            int maxLength = 200 - ((DirectoryPath + "/" + voiceName + "/" + speaker).Length);
+            maxLength -= missingFromDirectoryPath;
+            if (cleanedSentence.Length > maxLength)
+                cleanedSentence = cleanedSentence.Substring(0, maxLength);
+
+            cleanedSentence = Regex.Replace(cleanedSentence, @"[^a-zA-Z0-9 _-]", "").Replace(" ", "_").Replace("-", "_");
+            return cleanedSentence;
+        }
+
         [Serializable]
         public class DialogueData
         {

--- a/XivVoices/Engine/XivEngine.cs
+++ b/XivVoices/Engine/XivEngine.cs
@@ -1996,18 +1996,26 @@ namespace XivVoices.Engine
                         reportedLines.Dequeue();
 
                     if (Database.Plugin.Config.AnnounceReports) this.Database.Plugin.Print($"Reporting line: \"{xivMessage.Sentence}\"");
+                    /*
                     try
                     {
                         HttpResponseMessage response = await client.GetAsync(this.Database.GetReportSource() + url);
                         response.EnsureSuccessStatusCode();
                         string responseBody = await response.Content.ReadAsStringAsync();
                     }
-                    catch (HttpRequestException e)
+                    catch (HttpRequestException e)*/
                     {
-                        Plugin.PluginLog.Error("Report failed, saving it Reports folder to be automatically sent later.");
+                        Plugin.PluginLog.Info("Report failed, saving it to the Reports folder to be automatically sent later.");
                         Directory.CreateDirectory(this.Database.ReportsPath);
-                        string fileName = Path.Combine(this.Database.ReportsPath, $"{xivMessage.Speaker}_{new Random().Next(10000, 99999)}.txt");
-                        await File.WriteAllTextAsync(fileName, url);
+                        string fileName;
+
+                        string speaker = xivMessage.Speaker;
+                        fileName = Database.CleanedSentenceAndSpeakerForFile(string.Empty, ref speaker, xivMessage.Sentence);
+
+                        fileName = Path.Combine(this.Database.ReportsPath, $"{speaker}_{fileName}.txt");
+
+                        if(!Path.Exists(fileName))
+                            await File.WriteAllTextAsync(fileName, url);
                     }
                 }
 

--- a/XivVoices/PluginWindow.cs
+++ b/XivVoices/PluginWindow.cs
@@ -540,32 +540,33 @@ public class PluginWindow : Window
             };
             ImGui.SameLine();
             ImGui.Text("Download missing lines individually if they exist");
-
+            */
             // Reports Enabled
             ImGui.Dummy(new Vector2(0, 8));
             var reports = this.Configuration.Reports;
             if (ImGui.Checkbox("##reports", ref reports))
             {
-                this.configuration.Reports = reports;
+                Configuration.Reports = reports;
                 needSave = true;
             };
             ImGui.SameLine();
             ImGui.Text("Report Missing Dialogues Automatically");
             ImGui.PushStyleColor(ImGuiCol.Text, new Vector4(0.6f, 0.25f, 0.25f, 1.0f));
             ImGui.Text("( English lines only, do not enable for other languages )");
+            ImGui.Text("( Currently lines are only recorded to be missing locally )");
             ImGui.PopStyleColor();
 
             // AnnounceReports
             var announceReports = this.Configuration.AnnounceReports;
             if (ImGui.Checkbox("##announceReports", ref announceReports))
             {
-                this.configuration.AnnounceReports = announceReports;
+                Configuration.AnnounceReports = announceReports;
                 needSave = true;
             };
             ImGui.SameLine();
             ImGui.Text("Announce Reported Lines");
 
-            */
+            
 
             // END
 


### PR DESCRIPTION
Overall this is just Arc's started solution build out.

Creating files in the Reports folder of the Data, to later be read and reported as the new solution for it needs it.
The latter not being implemented as details are still being discussed.

In the Database.cs I decided to extract the sanitizing of the message and author into its own method to emulate the same filenames as the voicelines (roughly) without repeating the code for it.