### PR TITLE
fix: dont press num+0 when talk addon not present

### DIFF
--- a/XivVoices/Engine/Audio.cs
+++ b/XivVoices/Engine/Audio.cs
@@ -121,7 +121,8 @@ namespace XivVoices.Engine
                     audioInfo.state = "stopped";
                     Plugin.PluginLog.Information($"PlayAudio ---> stopped");
                     audioInfo.percentage = 1f;
-                    Plugin.ClickTalk();
+                    if (xivMessage.ChatType == "Dialogue")
+                        Plugin.ClickTalk();
                 }
                 catch (Exception ex)
                 {

--- a/XivVoices/Plugin.cs
+++ b/XivVoices/Plugin.cs
@@ -565,7 +565,7 @@ public class Plugin : IDalamudPlugin
 
     public void ClickTalk()
     {
-        if (Config.TextAutoAdvanceEnabled && !PlayerIsBoundByDuty())
+        if (Config.TextAutoAdvanceEnabled && !PlayerIsBoundByDuty() && _addonTalkManager.IsVisible())
             SetKeyValue(VirtualKey.NUMPAD0, KeyStateFlags.Pressed);
     }
 


### PR DESCRIPTION
Fixes press num+0 when there is no talk addon present to advance
and only clicksTalk on ChatType Dialogue